### PR TITLE
Fix fmt string in mirror HTML

### DIFF
--- a/internal/wrench/http_pkg.go
+++ b/internal/wrench/http_pkg.go
@@ -61,7 +61,7 @@ func (b *Bot) httpMuxPkgProxy(handler func(prefix string, handle handlerFunc) ht
 func (b *Bot) httpPkgZigRoot(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	fmt.Fprintf(w, "%s", `
+	fmt.Fprintf(w, `
 <h1 style="margin-bottom: 0.25rem;">Zig download mirror</h1>
 
 <div>


### PR DESCRIPTION
Before:

```
The rewrite logic is as follows:

https://ziglang.org/builds/$FILE -> %s/zig/$FILE

...

%!(EXTRA string=http://localhost)
```

After:

```
The rewrite logic is as follows:

https://ziglang.org/builds/$FILE -> http://localhost/zig/$FILE
```

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.