### PR TITLE
Don't cache 4xx/5xx errors permanently for files from stable releases

### DIFF
--- a/internal/wrench/http_pkg.go
+++ b/internal/wrench/http_pkg.go
@@ -420,7 +420,9 @@ func (b *Bot) httpPkgEnsureZigDownloadCached(version, versionKind, fname string)
 	cachedResponsesMu.Unlock()
 	if isCachedError {
 		if cachedError.expire >= time.Now().Unix() {
+			cachedResponsesMu.Lock()
 			delete(cachedResponses, url)
+			cachedResponsesMu.Unlock()
 			fmt.Fprintf(logWriter, "deleted cached error for %s (cached error %s)\n", url, cachedError.err)
 		} else {
 			fmt.Fprintf(logWriter, "not fetching: %s (cached error %s)\n", url, cachedError.err)

--- a/internal/wrench/http_pkg.go
+++ b/internal/wrench/http_pkg.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -429,6 +430,24 @@ func (b *Bot) httpPkgEnsureZigDownloadCached(version, versionKind, fname string)
 	if resp.StatusCode >= 400 && resp.StatusCode <= 500 {
 		// 404 not found, 403 forbidden, etc.
 		err := fmt.Errorf("bad response status: %s", resp.Status)
+
+		// file not available from upstream (but we expect it to be reachable)
+		// does not consider how to handle 429s from upstream
+		if (resp.StatusCode == 404 || resp.StatusCode >= 500) && versionKind == "stable" {
+			versionParts := strings.Split(version, ".")
+
+			// fail silently, this is probably fine
+			if i, e := strconv.ParseInt(versionParts[1], 10, 64); e == nil {
+				// versions below 0.5.0 are allowed to be unavailable
+				if !(versionParts[0] == "0" && i <= 5) {
+					// don't cache error, we expect it to be reachable later
+					fmt.Fprintf(logWriter, "error not cached: unexpected %v response for files with release %s", resp.StatusCode, version)
+					return err
+				}
+
+			}
+		}
+
 		cachedResponsesMu.Lock()
 		cachedResponses[url] = err
 		cachedResponsesMu.Unlock()

--- a/internal/wrench/http_pkg.go
+++ b/internal/wrench/http_pkg.go
@@ -354,9 +354,14 @@ func (b *Bot) httpPkgEnsureZigVersionCached(version, versionKind string) {
 	}
 }
 
+type cachedResponse struct {
+	err    error
+	expire int64 // seconds
+}
+
 var (
 	cachedResponsesMu sync.Mutex
-	cachedResponses   = map[string]error{}
+	cachedResponses   = map[string]cachedResponse{}
 	fsParallelismLock sync.Mutex
 )
 
@@ -414,8 +419,13 @@ func (b *Bot) httpPkgEnsureZigDownloadCached(version, versionKind, fname string)
 	cachedError, isCachedError := cachedResponses[url]
 	cachedResponsesMu.Unlock()
 	if isCachedError {
-		fmt.Fprintf(logWriter, "not fetching: %s (cached error %s)\n", url, cachedError)
-		return cachedError
+		if cachedError.expire >= time.Now().Unix() {
+			delete(cachedResponses, url)
+			fmt.Fprintf(logWriter, "deleted cached error for %s (cached error %s)\n", url, cachedError.err)
+		} else {
+			fmt.Fprintf(logWriter, "not fetching: %s (cached error %s)\n", url, cachedError.err)
+			return cachedError.err
+		}
 	}
 	fmt.Fprintf(logWriter, "fetch: %s > %s\n", url, filePath)
 
@@ -431,6 +441,9 @@ func (b *Bot) httpPkgEnsureZigDownloadCached(version, versionKind, fname string)
 		// 404 not found, 403 forbidden, etc.
 		err := fmt.Errorf("bad response status: %s", resp.Status)
 
+		// no expiry by default, cache forever
+		var expiry = int64(0)
+
 		// file not available from upstream (but we expect it to be reachable)
 		// does not consider how to handle 429s from upstream
 		if (resp.StatusCode == 404 || resp.StatusCode >= 500) && versionKind == "stable" {
@@ -440,16 +453,18 @@ func (b *Bot) httpPkgEnsureZigDownloadCached(version, versionKind, fname string)
 			if i, e := strconv.ParseInt(versionParts[1], 10, 64); e == nil {
 				// versions below 0.5.0 are allowed to be unavailable
 				if !(versionParts[0] == "0" && i <= 5) {
-					// don't cache error, we expect it to be reachable later
-					fmt.Fprintf(logWriter, "error not cached: unexpected %v response for files with release %s", resp.StatusCode, version)
-					return err
+					// cache for 5 mins, we expect it to be reachable later
+					expiry = time.Now().Unix() + (60 * 5)
+					fmt.Fprintf(logWriter, "error cached with expiry: unexpected %v response for files with release %s", resp.StatusCode, version)
 				}
-
 			}
 		}
 
 		cachedResponsesMu.Lock()
-		cachedResponses[url] = err
+		cachedResponses[url] = cachedResponse{
+			err:    err,
+			expire: expiry,
+		}
 		cachedResponsesMu.Unlock()
 		return err
 	}


### PR DESCRIPTION
Wrench's Zig mirror service currently caches 404 errors for files that are expected to be available, like files from releases (see: https://github.com/hexops/mach/issues/1416, https://github.com/mlugg/setup-zig/issues/33).

This PR checks if the requested file belongs to a stable version and has a version number greater than 0.5.0 (see: https://github.com/mlugg/setup-zig#adding-a-mirror), and prevents caching 4xx/5xx errors for those files, since it is expected that these files should be available later.

As a followup, we should also check if the version of the file being requested corresponds to the version string of the latest Zig master or latest Mach nominated version and not cache 4xx/5xx errors for those as well.

A better approach may be to read the index file and ensure all versions present there won't have their 4xx/5xx errors cached.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.